### PR TITLE
Url params no longer nullable

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget id="com.wyomingsoftware.noditor" version="1.0.4" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget android-versionCode="10004" id="com.wyomingsoftware.noditor" version="1.0.4" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>Noditor</name>
     <description>Node.js mobile monitor.</description>
     <author email="warren@wyomingsoftware.com" href="https://github.com/WyomingSoftware">Wyoming Software</author>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "Noditor",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Noditor",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "author": "Wyoming Software",
   "homepage": "https://github.com/WyomingSoftware",
   "private": true,

--- a/src/pages/servers/server-setup.ts
+++ b/src/pages/servers/server-setup.ts
@@ -76,15 +76,14 @@ import { HintsComponent } from '../../components/hints';
           [hints]="['<b>Name:</b> A descriptive name for the server. For display purposes only.',
 
           '<b>URL:</b> The full URL to the server including the communication protocol (http or https).
-          Include the port if not 80 or 443. Do not include any part of the URI or a query string.
+          Include the port if not 80 or 443. Do not include any part of an endpoint call or a query string.
           <br/><br/>&nbsp;&nbsp;&nbsp;Example: https://www.noditor.com:8443',
 
-          '<b>Passcode:</b> If you started the Noditor Module with a passcode you
-          will need to place it here.',
+          '<b>Passcode:</b> If the Noditor Module was stated with a passcode, place it here.',
 
-          '<b>Path:</b> This is a placeholder for your load balancer to use and direct the URL to the
+          '<b>Path:</b> This is a placeholder for a load balancer to use and direct the URL to the
           proper server. It is ignored by the Noditor Module.
-          If you are not directing the URL with a load balancer leave this empty.']">
+          Leave this empty when not directing the URL via a load balancer.']">
       </hints-selector>
 
     </ion-content>
@@ -229,7 +228,13 @@ export class ServerSetupModal {
     });
     loader.present();
 
-    this.httpService.get(this.theServer.url+'/noditor/'+this.theServer.path+'/'+this.theServer.passcode+'/top', 5)
+    // The path or passcode cannot be null
+    var path = this.theServer.path;
+    if(!this.theServer.path) path = '-';
+    var passcode = this.theServer.passcode;
+    if(!this.theServer.passcode) passcode = '-';
+
+    this.httpService.get(this.theServer.url+'/noditor/'+path+'/'+passcode+'/top', 5)
     .then((data: any) => {
       loader.dismiss();
       this.testMsg = "Connected";

--- a/src/pages/servers/servers.ts
+++ b/src/pages/servers/servers.ts
@@ -198,7 +198,13 @@ export class ServersPage {
   load(server:any, loader:any):void{
     if(loader){ loader.present(); }
 
-    this.httpService.get(server.url+'/noditor/'+server.path+'/'+server.passcode+'/top', 5)
+    // The path or passcode cannot be null
+    var path = server.path;
+    if(!server.path) path = '-';
+    var passcode = server.passcode;
+    if(!server.passcode) passcode = '-';
+
+    this.httpService.get(server.url+'/noditor/'+path+'/'+passcode+'/top', 5)
     .then((data: any) => {
       try{
         //console.log('ServersPage.load', 'Timeout > ', this.timeoutValue, data)

--- a/src/pages/stats/stats-details.ts
+++ b/src/pages/stats/stats-details.ts
@@ -387,7 +387,14 @@ export class StatsDetailsPage {
   load(loader):void{
     this.errorMsg = null;
     this.errorHints = false;
-    this.httpService.get(this.server.url+'/noditor/'+this.server.path+'/'+this.server.passcode+'/stats', 5)
+
+    // The path or passcode cannot be null
+    var path = this.server.path;
+    if(!this.server.path) path = '-';
+    var passcode = this.server.passcode;
+    if(!this.server.passcode) passcode = '-';
+
+    this.httpService.get(this.server.url+'/noditor/'+path+'/'+passcode+'/stats', 5)
     .then((data: any) => {
       try{
         //console.log('StatsDetailsPage.load DATA', 'timer value >', this.timeoutValue, data)


### PR DESCRIPTION
Null parameters values in the REST URL would generate a 404 with newer versions of Express. It is possible other REST frameworks might do the same. Nothing changes for the user. If the path and/or passcode are not entered by the user (they remain optional) as the app simply sends a dash (-) in place of the null.